### PR TITLE
feat: 手動での入金消込（代理操作）機能の実装 (#4)

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -91,3 +91,30 @@ export async function deleteContractor(formData: FormData) {
     revalidatePath('/admin')
     return { success: true }
 }
+
+export async function createManualPayment(formData: FormData) {
+    const userId = formData.get('userId') as string
+    const amount = parseInt(formData.get('amount') as string)
+    const targetMonth = formData.get('targetMonth') as string
+
+    const supabase = await createClient()
+
+    const { error } = await supabase
+        .from('payments')
+        .insert({
+            user_id: userId,
+            amount: amount,
+            currency: 'jpy',
+            status: 'succeeded',
+            target_month: targetMonth,
+            stripe_session_id: 'manual_entry', // Mark as manual payment
+        })
+
+    if (error) {
+        console.error('Error creating manual payment:', error)
+        return { error: '入金記録の作成に失敗しました' }
+    }
+
+    revalidatePath('/admin')
+    return { success: true }
+}

--- a/app/admin/manual-payment-dialog.tsx
+++ b/app/admin/manual-payment-dialog.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+import { createManualPayment } from "./actions"
+import { BadgeJapaneseYen } from "lucide-react"
+
+type ManualPaymentDialogProps = {
+    contractorId: string
+    contractorName: string
+    monthlyFee: number
+    unpaidMonths: string[]
+}
+
+export function ManualPaymentDialog({ contractorId, contractorName, monthlyFee, unpaidMonths }: ManualPaymentDialogProps) {
+    const [open, setOpen] = useState(false)
+    const [selectedMonths, setSelectedMonths] = useState<Set<string>>(new Set())
+
+    const handleMonthToggle = (month: string) => {
+        const newSelected = new Set(selectedMonths)
+        if (newSelected.has(month)) {
+            newSelected.delete(month)
+        } else {
+            newSelected.add(month)
+        }
+        setSelectedMonths(newSelected)
+    }
+
+    async function handleSubmit() {
+        if (selectedMonths.size === 0) return
+
+        if (!confirm(`${selectedMonths.size}ヶ月分の入金を消込しますか？`)) {
+            return
+        }
+
+        // Process sequentially to keep simple logic (could be parallelized)
+        for (const month of Array.from(selectedMonths)) {
+            const formData = new FormData()
+            formData.append('userId', contractorId)
+            formData.append('amount', monthlyFee.toString())
+            formData.append('targetMonth', month)
+
+            const result = await createManualPayment(formData)
+            if (result?.error) {
+                alert(`${month}分の消込に失敗しました: ${result.error}`)
+            }
+        }
+
+        setOpen(false)
+        setSelectedMonths(new Set())
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+                <Button variant="ghost" size="icon" className="text-blue-500 hover:text-blue-700 hover:bg-blue-50">
+                    <BadgeJapaneseYen className="h-5 w-5" />
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[425px]">
+                <DialogHeader>
+                    <DialogTitle>手動入金消込</DialogTitle>
+                    <DialogDescription>
+                        {contractorName}さんの未払い月を入金済みとして記録します。<br />
+                        現金や振込で受領した場合に使用してください。
+                    </DialogDescription>
+                </DialogHeader>
+
+                {unpaidMonths.length === 0 ? (
+                    <div className="py-6 text-center text-gray-500">
+                        未払いの月はありません。
+                    </div>
+                ) : (
+                    <div className="grid gap-4 py-4 max-h-[300px] overflow-y-auto">
+                        <p className="text-sm font-medium mb-2">未払い月一覧</p>
+                        {unpaidMonths.map((month) => (
+                            <div key={month} className="flex items-center space-x-2 border p-3 rounded-md">
+                                <Checkbox
+                                    id={`month-${month}`}
+                                    checked={selectedMonths.has(month)}
+                                    onCheckedChange={() => handleMonthToggle(month)}
+                                />
+                                <Label htmlFor={`month-${month}`} className="flex-1 cursor-pointer flex justify-between items-center">
+                                    <span>{month}</span>
+                                    <span className="text-gray-500">¥{monthlyFee.toLocaleString()}</span>
+                                </Label>
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                <DialogFooter>
+                    <div className="flex w-full justify-between items-center">
+                        <span className="font-bold">
+                            合計: ¥{(selectedMonths.size * monthlyFee).toLocaleString()}
+                        </span>
+                        <Button onClick={handleSubmit} disabled={selectedMonths.size === 0}>
+                            消込実行
+                        </Button>
+                    </div>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/utils/supabase/server"
 import { AddContractorDialog } from "./add-contractor-dialog"
 import { EditContractorDialog } from "./edit-contractor-dialog"
 import { DeleteContractorButton } from "./delete-contractor-button"
+import { ManualPaymentDialog } from "./manual-payment-dialog"
 import {
     Table,
     TableBody,
@@ -130,6 +131,12 @@ export default async function AdminPage() {
                                         </TableCell>
                                         <TableCell className="text-right">
                                             <div className="flex justify-end gap-2">
+                                                <ManualPaymentDialog
+                                                    contractorId={contractor.id}
+                                                    contractorName={contractor.full_name}
+                                                    monthlyFee={contractor.monthly_fee}
+                                                    unpaidMonths={unpaidMonths}
+                                                />
                                                 <EditContractorDialog contractor={contractor} />
                                                 <DeleteContractorButton id={contractor.id} name={contractor.full_name} />
                                             </div>

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.11",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
@@ -1290,6 +1291,88 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
@@ -2334,6 +2417,20 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",


### PR DESCRIPTION
管理者がStripeを介さず現金等で受領した支払いを、システム上で「支払済」として記録する代理操作機能を実装しました。
これにより、オンライン決済以外の入金フローに対応し、滞納ステータスの正確な管理が可能になります。

## 変更内容

### UI/UX
- 管理画面: 契約者一覧の操作列に「入金記録」ボタン（BadgeJapaneseYenアイコン）を追加
- 消込ダイアログ:
  - ManualPaymentDialogコンポーネントを新規作成
  - 未払い月（Arrears）のみを自動抽出し、チェックボックスで複数月を一括選択可能に
  - 合計金額をリアルタイムで表示し、誤入力を防止

### サーバーサイド
- アクション: createManualPaymentを追加
  - 指定された月 (target_month) と金額で payments テーブルにレコードを挿入
  - stripe_session_id には識別子として 'manual_entry' を記録
  - 処理完了後に管理画面を再検証 (revalidatePath) し、滞納カウントを即座に反映

## 技術的詳細
- ダイアログ内の未払い月リストは、親コンポーネント (AdminPage) の計算ロジックと整合性を保つため、Propsとして受け渡す設計を採用
- UX向上のため、lucide-react の通貨バッジアイコンを採用し、視認性を確保

Closes #4