### PR TITLE
feat: 銀行振込対応の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# supabase
+supabase/.temp/
+supabase/.branches/
+supabase/migrations/

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -34,7 +34,19 @@ export default async function AdminLayout({
         <div className="min-h-screen bg-gray-50">
             <header className="bg-white shadow-sm">
                 <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
-                    <h1 className="text-xl font-bold text-gray-900">Owner Dashboard</h1>
+                    <div className="flex items-center gap-6">
+                        <a href="/admin" className="text-xl font-bold text-gray-900 hover:text-gray-700">
+                            Owner Dashboard
+                        </a>
+                        <nav className="flex gap-4">
+                            <a href="/admin" className="text-sm font-medium text-gray-700 hover:text-gray-900">
+                                契約者一覧
+                            </a>
+                            <a href="/admin/settings" className="text-sm font-medium text-gray-700 hover:text-gray-900">
+                                設定
+                            </a>
+                        </nav>
+                    </div>
                     <form action={logout}>
                         <Button variant="outline" size="sm">
                             Sign Out

--- a/app/admin/manual-payment-dialog.tsx
+++ b/app/admin/manual-payment-dialog.tsx
@@ -26,6 +26,7 @@ type ManualPaymentDialogProps = {
 export function ManualPaymentDialog({ contractorId, contractorName, monthlyFee, unpaidMonths }: ManualPaymentDialogProps) {
     const [open, setOpen] = useState(false)
     const [selectedMonths, setSelectedMonths] = useState<Set<string>>(new Set())
+    const [paymentMethod, setPaymentMethod] = useState<'cash' | 'bank_transfer'>('cash')
 
     const handleMonthToggle = (month: string) => {
         const newSelected = new Set(selectedMonths)
@@ -40,7 +41,8 @@ export function ManualPaymentDialog({ contractorId, contractorName, monthlyFee, 
     async function handleSubmit() {
         if (selectedMonths.size === 0) return
 
-        if (!confirm(`${selectedMonths.size}ヶ月分の入金を消込しますか？`)) {
+        const methodText = paymentMethod === 'cash' ? '現金' : '銀行振込'
+        if (!confirm(`${selectedMonths.size}ヶ月分の入金（${methodText}）を消込しますか？`)) {
             return
         }
 
@@ -50,6 +52,7 @@ export function ManualPaymentDialog({ contractorId, contractorName, monthlyFee, 
             formData.append('userId', contractorId)
             formData.append('amount', monthlyFee.toString())
             formData.append('targetMonth', month)
+            formData.append('paymentMethod', paymentMethod)
 
             const result = await createManualPayment(formData)
             if (result?.error) {
@@ -83,6 +86,34 @@ export function ManualPaymentDialog({ contractorId, contractorName, monthlyFee, 
                     </div>
                 ) : (
                     <div className="grid gap-4 py-4 max-h-[300px] overflow-y-auto">
+                        <div className="space-y-2 mb-4">
+                            <Label>支払い方法</Label>
+                            <div className="flex items-center space-x-4">
+                                <label className="flex items-center space-x-2 cursor-pointer">
+                                    <input
+                                        type="radio"
+                                        name="paymentMethod"
+                                        value="cash"
+                                        checked={paymentMethod === 'cash'}
+                                        onChange={(e) => setPaymentMethod(e.target.value as 'cash')}
+                                        className="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+                                    />
+                                    <span>現金</span>
+                                </label>
+                                <label className="flex items-center space-x-2 cursor-pointer">
+                                    <input
+                                        type="radio"
+                                        name="paymentMethod"
+                                        value="bank_transfer"
+                                        checked={paymentMethod === 'bank_transfer'}
+                                        onChange={(e) => setPaymentMethod(e.target.value as 'bank_transfer')}
+                                        className="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+                                    />
+                                    <span>銀行振込</span>
+                                </label>
+                            </div>
+                        </div>
+
                         <p className="text-sm font-medium mb-2">未払い月一覧</p>
                         {unpaidMonths.map((month) => (
                             <div key={month} className="flex items-center space-x-2 border p-3 rounded-md">

--- a/app/admin/settings/owner-settings-form.tsx
+++ b/app/admin/settings/owner-settings-form.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { updateOwnerSettings } from "@/app/admin/actions"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+
+import { useTransition, useState } from "react"
+// import { useToast } from "@/hooks/use-toast"
+
+interface OwnerSettingsFormProps {
+    initialData: {
+        company_name: string | null
+        address: string | null
+        invoice_registration_number: string | null
+        bank_name: string | null
+        bank_branch_name: string | null
+        account_type: string | null
+        account_number: string | null
+        account_holder_name: string | null
+    }
+}
+
+export function OwnerSettingsForm({ initialData }: OwnerSettingsFormProps) {
+    const [isPending, startTransition] = useTransition()
+    const [message, setMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null)
+
+    const handleSubmit = async (formData: FormData) => {
+        startTransition(async () => {
+            const result = await updateOwnerSettings(formData)
+            if (result.error) {
+                setMessage({ type: 'error', text: result.error })
+            } else {
+                setMessage({ type: 'success', text: "設定を更新しました。" })
+                // Hide message after 3 seconds
+                setTimeout(() => setMessage(null), 3000)
+            }
+        })
+    }
+
+    return (
+        <form action={handleSubmit} className="space-y-8">
+            {message && (
+                <div className={`p-4 rounded-md ${message.type === 'error' ? 'bg-red-50 text-red-900' : 'bg-green-50 text-green-900'}`}>
+                    {message.text}
+                </div>
+            )}
+            <Card>
+                <CardHeader>
+                    <CardTitle>事業者情報</CardTitle>
+                    <CardDescription>
+                        請求書や領収書に表示される情報です。
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="companyName">屋号・会社名</Label>
+                            <Input
+                                id="companyName"
+                                name="companyName"
+                                defaultValue={initialData.company_name || ""}
+                                placeholder="例: 駐車場 管理太郎"
+                                required
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="invoiceNumber">インボイス登録番号</Label>
+                            <Input
+                                id="invoiceNumber"
+                                name="invoiceNumber"
+                                defaultValue={initialData.invoice_registration_number || ""}
+                                placeholder="例: T1234567890123"
+                            />
+                        </div>
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="address">住所</Label>
+                        <Input
+                            id="address"
+                            name="address"
+                            defaultValue={initialData.address || ""}
+                            placeholder="例: 〒100-0001 東京都千代田区千代田1-1"
+                        />
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>振込先口座情報</CardTitle>
+                    <CardDescription>
+                        銀行振込を選択した契約者に表示される情報です。
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="bankName">銀行名</Label>
+                            <Input
+                                id="bankName"
+                                name="bankName"
+                                defaultValue={initialData.bank_name || ""}
+                                placeholder="例: みずほ銀行"
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="branchName">支店名</Label>
+                            <Input
+                                id="branchName"
+                                name="branchName"
+                                defaultValue={initialData.bank_branch_name || ""}
+                                placeholder="例: 丸の内支店"
+                            />
+                        </div>
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="accountType">口座種別</Label>
+                            <div className="flex items-center space-x-4 pt-2">
+                                <label className="flex items-center space-x-2">
+                                    <input
+                                        type="radio"
+                                        name="accountType"
+                                        value="ordinary"
+                                        defaultChecked={initialData.account_type === "ordinary" || !initialData.account_type}
+                                        className="h-4 w-4 border-gray-300 text-primary focus:ring-primary"
+                                    />
+                                    <span>普通</span>
+                                </label>
+                                <label className="flex items-center space-x-2">
+                                    <input
+                                        type="radio"
+                                        name="accountType"
+                                        value="current"
+                                        defaultChecked={initialData.account_type === "current"}
+                                        className="h-4 w-4 border-gray-300 text-primary focus:ring-primary"
+                                    />
+                                    <span>当座</span>
+                                </label>
+                            </div>
+                        </div>
+                        <div className="space-y-2 col-span-2">
+                            <Label htmlFor="accountNumber">口座番号</Label>
+                            <Input
+                                id="accountNumber"
+                                name="accountNumber"
+                                defaultValue={initialData.account_number || ""}
+                                placeholder="例: 1234567"
+                            />
+                        </div>
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="accountHolder">口座名義（カナ）</Label>
+                        <Input
+                            id="accountHolder"
+                            name="accountHolder"
+                            defaultValue={initialData.account_holder_name || ""}
+                            placeholder="例: チュウシャジョウ　カンリタロウ"
+                        />
+                    </div>
+                </CardContent>
+            </Card>
+
+            <div className="flex justify-end">
+                <Button type="submit" disabled={isPending}>
+                    {isPending ? "保存中..." : "保存する"}
+                </Button>
+            </div>
+        </form>
+    )
+}

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -1,0 +1,38 @@
+import { createClient } from "@/utils/supabase/server"
+import { OwnerSettingsForm } from "./owner-settings-form"
+import { redirect } from "next/navigation"
+
+export default async function SettingsPage() {
+    const supabase = await createClient()
+
+    const {
+        data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+        redirect("/login")
+    }
+
+    const { data: profile } = await supabase
+        .from("profiles")
+        .select("*")
+        .eq("auth_id", user.id)
+        .eq("role", "owner")
+        .single()
+
+    if (!profile) {
+        return <div>Owner profile not found</div>
+    }
+
+    return (
+        <div className="max-w-2xl mx-auto space-y-6">
+            <div>
+                <h2 className="text-3xl font-bold tracking-tight">設定</h2>
+                <p className="text-muted-foreground">
+                    事業者情報や振込先口座の管理を行えます。
+                </p>
+            </div>
+            <OwnerSettingsForm initialData={profile} />
+        </div>
+    )
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -45,7 +45,7 @@ export default async function LoginPage({
                                 <form action={loginContractor} className="space-y-4">
                                     <div className="space-y-2">
                                         <Label htmlFor="name">お名前</Label>
-                                        <Input id="name" name="name" placeholder="例: 田中" required />
+                                        <Input id="name" name="name" placeholder="例: 田中太郎" required />
                                     </div>
                                     <div className="space-y-2">
                                         <Label htmlFor="phone">電話番号下4桁</Label>

--- a/supabase/1-schema.sql
+++ b/supabase/1-schema.sql
@@ -19,6 +19,11 @@ create table if not exists public.profiles (
   company_name text, -- Owner's company name or trade name
   address text, -- Owner's address for receipts
   invoice_registration_number text, -- Owner's Invoice Registration Number (e.g. T1234567890123)
+  bank_name text, -- Owner's Bank Name
+  bank_branch_name text, -- Owner's Bank Branch Name
+  account_type text, -- 'ordinary' (futsu) or 'current' (toza)
+  account_number text, -- Account Number
+  account_holder_name text, -- Account Holder Name
   created_at timestamp with time zone default timezone('utc'::text, now()) not null
 );
 
@@ -31,6 +36,7 @@ create table if not exists public.payments (
   status text not null check (status in ('pending', 'succeeded', 'failed')),
   target_month text not null, -- Format: YYYY-MM
   stripe_session_id text,
+  payment_method text check (payment_method in ('stripe', 'cash', 'bank_transfer')), -- 'stripe', 'cash', 'bank_transfer'
   created_at timestamp with time zone default timezone('utc'::text, now()) not null
 );
 

--- a/supabase/2-seed.sql
+++ b/supabase/2-seed.sql
@@ -1,34 +1,34 @@
 -- Seed Owner (You must update the auth_id after creating the user in Auth > Users)
 -- For now, we insert a placeholder. The user needs to sign up, then update this record.
-insert into public.profiles (full_name, role, monthly_fee, phone_number, phone_last4, contract_start_month, contract_end_month, company_name, address, invoice_registration_number)
+insert into public.profiles (full_name, role, monthly_fee, phone_number, phone_last4, contract_start_month, contract_end_month, company_name, address, invoice_registration_number, bank_name, bank_branch_name, account_type, account_number, account_holder_name)
 values 
-('Owner', 'owner', 0, null, null, null, null, '駐車場 管理太郎', '〒100-0001 東京都千代田区千代田1-1', 'T1234567890123')
+('Owner', 'owner', 0, null, null, null, null, '駐車場 管理太郎', '〒100-0001 東京都千代田区千代田1-1', 'T1234567890123', 'みずほ銀行', '丸の内支店', 'ordinary', '1234567', 'チュウシャジョウ　カンリタロウ')
 on conflict (full_name) do nothing;
 
 -- Seed Test Contractors
 -- We use specific UUIDs to ensure relationships with payments work correctly
 insert into public.profiles (id, full_name, role, monthly_fee, phone_number, phone_last4, contract_start_month, contract_end_month)
 values 
-('defea0fc-d619-4ca7-9f81-854d6e427acb', '田中 次郎', 'contractor', 3000, '08012341234', '1234', '2025-12', null),
-('3b4d185a-8051-4327-bb2f-521fbc09f4df', '鈴木 花子', 'contractor', 3000, '070-1234-1234', '1234', '2025-12', null),
-('ff6308b6-4565-4771-810f-1dcafc53a831', '佐々木 健太', 'contractor', 3000, '09012341234', '1234', '2025-12', null),
-('4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', '佐藤 一郎', 'contractor', 3000, '09087651234', '1234', '2025-05', '2026-12'),
-('d110a286-633c-474d-926e-4048f77df4ed', '山田 太郎', 'contractor', 3000, '09012341234', '1234', '2025-11', '2026-11'),
-('ff0f07aa-e065-4d6a-bc7c-33ed094d7fe1', '大沼 その子', 'contractor', 3000, '09012341234', '1234', '2025-08', '2026-07')
+('defea0fc-d619-4ca7-9f81-854d6e427acb', '田中次郎', 'contractor', 3000, '08012341234', '1234', '2025-12', null),
+('3b4d185a-8051-4327-bb2f-521fbc09f4df', '鈴木花子', 'contractor', 3000, '07012341234', '1234', '2025-12', null),
+('ff6308b6-4565-4771-810f-1dcafc53a831', '佐々木健太', 'contractor', 3000, '09012341234', '1234', '2025-12', null),
+('4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', '佐藤一郎', 'contractor', 3000, '09087651234', '1234', '2025-05', '2026-12'),
+('d110a286-633c-474d-926e-4048f77df4ed', '山田太郎', 'contractor', 3000, '09012341234', '1234', '2025-11', '2026-11'),
+('ff0f07aa-e065-4d6a-bc7c-33ed094d7fe1', '大沼その子', 'contractor', 3000, '09012341234', '1234', '2025-08', '2026-07')
 on conflict (full_name) do nothing; -- Note: ideally we should upsert on ID, but full_name is unique
 
 -- Seed Payments
-insert into public.payments (id, user_id, amount, currency, status, target_month, stripe_session_id, created_at)
+insert into public.payments (id, user_id, amount, currency, status, target_month, stripe_session_id, payment_method, created_at)
 values
-('003b6165-44d2-45a0-9015-2166a697608d', '4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', 3000, 'jpy', 'succeeded', '2025-09', 'manual_entry', '2025-12-07 04:24:33.620162+00'),
-('0b0b153a-9f3a-4479-9853-a13fee41e046', '4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', 3000, 'jpy', 'succeeded', '2025-07', 'manual_entry', '2025-12-07 04:24:32.236404+00'),
-('2771ec09-f800-4199-a511-b5141aa2b96c', '4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', 3000, 'jpy', 'succeeded', '2025-10', 'manual_entry', '2025-12-07 04:38:02.742737+00'),
-('3c583302-b5ba-4f57-9a8a-f4fab6f154f3', '4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', 3000, 'jpy', 'succeeded', '2025-11', 'manual_entry', '2025-12-07 04:38:02.090534+00'),
-('5bf1471a-d58f-418c-87ca-23184df423aa', 'ff0f07aa-e065-4d6a-bc7c-33ed094d7fe1', 3000, 'jpy', 'succeeded', '2025-12', 'manual_entry', '2025-12-07 04:37:42.245194+00'),
-('6c272dc8-4d3a-472a-a4d0-7060a59e5eb6', 'ff6308b6-4565-4771-810f-1dcafc53a831', 3000, 'jpy', 'succeeded', '2025-12', 'manual_entry', '2025-12-07 04:24:17.555976+00'),
-('6e1b3493-0308-4f6d-a047-7f1d24afb40d', '4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', 3000, 'jpy', 'succeeded', '2025-08', 'manual_entry', '2025-12-07 04:38:03.276346+00'),
-('77095faa-dd36-4d76-bf4e-a0ea0b6ba9c0', 'defea0fc-d619-4ca7-9f81-854d6e427acb', 12000, 'jpy', 'succeeded', '2025-12', 'cs_test_a12B0m6Vf5PBiBzbgJK0rsqz2mnpVA4n19unuO13EY4mRNnPWXqo0IJsIe', '2025-12-05 11:08:12.088388+00'),
-('9a227faa-6fcd-4876-b3e2-6eb6540bf429', '4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', 3000, 'jpy', 'succeeded', '2025-12', 'cs_test_a1Bdi771sSIKJ7RtAkOAuaXRO81mgsLKrZNOnfRqB0ZNmLvaP2XicZdIgo', '2025-12-06 08:52:41.440544+00'),
-('c6704bc5-b700-4635-91fd-e83395e60b02', 'd110a286-633c-474d-926e-4048f77df4ed', 3000, 'jpy', 'succeeded', '2025-11', 'cs_test_a17SjROGMCX8CNuishbXJo5uO05E7DnqdWonCrHJkPH9KnVDZvDfpQxaYt', '2025-12-05 11:21:35.291879+00'),
-('d6f4929e-b1dc-4889-8872-47420597506a', 'd110a286-633c-474d-926e-4048f77df4ed', 3000, 'jpy', 'succeeded', '2025-12', 'cs_test_a1LfciilrGXx4Is2VV6W2VlxIPiv5R1KAPBZAL3SydLKHKY4qFogrH4Hh2', '2025-12-05 12:03:30.016008+00')
+('003b6165-44d2-45a0-9015-2166a697608d', '4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', 3000, 'jpy', 'succeeded', '2025-09', 'manual_entry', 'cash', '2025-12-07 04:24:33.620162+00'),
+('0b0b153a-9f3a-4479-9853-a13fee41e046', '4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', 3000, 'jpy', 'succeeded', '2025-07', 'manual_entry', 'cash', '2025-12-07 04:24:32.236404+00'),
+('2771ec09-f800-4199-a511-b5141aa2b96c', '4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', 3000, 'jpy', 'succeeded', '2025-10', 'manual_entry', 'cash', '2025-12-07 04:38:02.742737+00'),
+('3c583302-b5ba-4f57-9a8a-f4fab6f154f3', '4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', 3000, 'jpy', 'succeeded', '2025-11', 'manual_entry', 'cash', '2025-12-07 04:38:02.090534+00'),
+('5bf1471a-d58f-418c-87ca-23184df423aa', 'ff0f07aa-e065-4d6a-bc7c-33ed094d7fe1', 3000, 'jpy', 'succeeded', '2025-12', 'manual_entry', 'cash', '2025-12-07 04:37:42.245194+00'),
+('6c272dc8-4d3a-472a-a4d0-7060a59e5eb6', 'ff6308b6-4565-4771-810f-1dcafc53a831', 3000, 'jpy', 'succeeded', '2025-12', 'manual_entry', 'cash', '2025-12-07 04:24:17.555976+00'),
+('6e1b3493-0308-4f6d-a047-7f1d24afb40d', '4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', 3000, 'jpy', 'succeeded', '2025-08', 'manual_entry', 'cash', '2025-12-07 04:38:03.276346+00'),
+('77095faa-dd36-4d76-bf4e-a0ea0b6ba9c0', 'defea0fc-d619-4ca7-9f81-854d6e427acb', 12000, 'jpy', 'succeeded', '2025-12', 'cs_test_a12B0m6Vf5PBiBzbgJK0rsqz2mnpVA4n19unuO13EY4mRNnPWXqo0IJsIe', 'stripe', '2025-12-05 11:08:12.088388+00'),
+('9a227faa-6fcd-4876-b3e2-6eb6540bf429', '4a1f37a8-533b-46c8-9c41-5b3f5ebcbe07', 3000, 'jpy', 'succeeded', '2025-12', 'cs_test_a1Bdi771sSIKJ7RtAkOAuaXRO81mgsLKrZNOnfRqB0ZNmLvaP2XicZdIgo', 'stripe', '2025-12-06 08:52:41.440544+00'),
+('c6704bc5-b700-4635-91fd-e83395e60b02', 'd110a286-633c-474d-926e-4048f77df4ed', 3000, 'jpy', 'succeeded', '2025-11', 'cs_test_a17SjROGMCX8CNuishbXJo5uO05E7DnqdWonCrHJkPH9KnVDZvDfpQxaYt', 'stripe', '2025-12-05 11:21:35.291879+00'),
+('d6f4929e-b1dc-4889-8872-47420597506a', 'd110a286-633c-474d-926e-4048f77df4ed', 3000, 'jpy', 'succeeded', '2025-12', 'cs_test_a1LfciilrGXx4Is2VV6W2VlxIPiv5R1KAPBZAL3SydLKHKY4qFogrH4Hh2', 'stripe', '2025-12-05 12:03:30.016008+00')
 on conflict (id) do nothing;


### PR DESCRIPTION
## 概要
銀行振込による支払いに対応しました。オーナーは銀行口座情報を登録・表示でき、契約者はポータル画面で振込先を確認できるようになりました。

## 主な変更内容

### データベース
- \`profiles\` テーブルに銀行口座情報フィールドを追加
- \`payments\` テーブルに payment_method カラムを追加
- Seed データ更新（銀行情報追加、契約者名正規化）

### 管理画面
- 新規: \`/admin/settings\` ページ（事業者情報・銀行口座情報編集）
- 更新: 手動入金ダイアログに支払い方法選択機能を追加

### ポータル画面
- 銀行振込情報セクションを追加（未払い月リストの下に配置）
- 振込名義に関する案内を表示

### その他
- .gitignore に Supabase 一時ファイルを追加
- ログイン画面のプレースホルダーを改善

Related to #9